### PR TITLE
Uses python3 absolute imports

### DIFF
--- a/pypal/resources.py
+++ b/pypal/resources.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import json
-from http import PayPalSession
+from .http import PayPalSession
 from pypal import API_BASE_URL, API_BASE_URL_SANDBOX
 
 


### PR DESCRIPTION
I'm using pypal for one of my projects and it doesn't work in python3. This will allow the library to work on python 2.7 and >= 3.4